### PR TITLE
Prepare for release with Pekko 1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,19 @@ val commonSettings = Seq(
   autoAPIMappings := true,
   versionScheme := Some("early-semver"),
   versionPolicyIntention := Compatibility.BinaryCompatible,
+
+  // TODO: remove after 1.1.0 release
+  versionPolicyIgnored ++= Seq(
+    // For 1.0.0, conhub module erroneously depended on the Akka version of sequentially.
+    // For 1.1.0, it was replaced with a Pekko version which generated "missing dependency" bincompat check failures.
+    // Since the clients had to exclude those accidental Akka dependencies anyway, this shouldn't affect real
+    // compatibility.
+    "com.typesafe.akka" %% "akka-actor",
+    "com.typesafe.akka" %% "akka-protobuf-v3",
+    "com.typesafe.akka" %% "akka-stream",
+    "com.evolutiongaming" %% "sequentially",
+    "org.scala-lang.modules" %% "scala-java8-compat",
+  ),
 )
 
 val alias =
@@ -112,6 +125,7 @@ lazy val pubsub = module("pubsub")
       Evo.CatsHelper,
       Evo.SCache,
       Scodec.Bits,
+      Evo.SMetrics,
       TestLib.ScalaTest % Test,
     ),
   )
@@ -129,6 +143,7 @@ lazy val testActor = module("test-actor")
     libraryDependencies ++= Seq(
       Pekko.Actor,
       TestLib.ScalaTest,
+      // needed for testing Pekko modules version mismatch logic
       Pekko.OlderSlf4j % Test,
     ),
   )
@@ -141,6 +156,7 @@ lazy val testHttp = module("test-http")
       Pekko.Stream,
       PekkoHttp.Core,
       TestLib.ScalaTest,
+      // needed for testing Pekko-Http modules version mismatch logic
       PekkoHttp.OlderTestkit % Test,
     ),
   )
@@ -282,7 +298,7 @@ lazy val conhub = module("conhub")
       Pekko.Protobuf,
       Evo.ConfigTools,
       Evo.FutureHelper,
-      Evo.Sequentially,
+      Evo.SequentiallyPekko,
       Misc.Logging,
       Cats.Core,
       Cats.Effect % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val ScalaTools = "com.evolutiongaming" %% "scala-tools" % "3.0.6"
     val ConfigTools = "com.evolutiongaming" %% "config-tools" % "1.0.5"
     val FutureHelper = "com.evolutiongaming" %% "future-helper" % "1.0.7"
-    val Sequentially = "com.evolutiongaming" %% "sequentially" % "2.0.6"
+    val SequentiallyPekko = "com.evolutiongaming" %% "sequentially-pekko" % "3.0.0"
     val SStream = "com.evolutiongaming" %% "sstream" % "1.1.0"
     val Retry = "com.evolutiongaming" %% "retry" % "3.1.0"
   }
@@ -33,7 +33,8 @@ object Dependencies {
     val Remote = "org.apache.pekko" %% "pekko-remote" % version
     val Protobuf = "org.apache.pekko" %% "pekko-protobuf-v3" % version
 
-    val OlderSlf4j = "org.apache.pekko" %% "pekko-slf4j" % "1.0.3"
+    // needed for testing Pekko modules version mismatch logic
+    val OlderSlf4j = "org.apache.pekko" %% "pekko-slf4j" % "1.1.5" // scala-steward:off
   }
 
   object PekkoHttp {
@@ -41,7 +42,8 @@ object Dependencies {
     val Core = "org.apache.pekko" %% "pekko-http-core" % version
     val Testkit = "org.apache.pekko" %% "pekko-http-testkit" % version
 
-    val OlderTestkit = "org.apache.pekko" %% "pekko-http-testkit" % "1.1.0" // scala-steward:off we need older version for tests
+    // needed for testing Pekko-Http modules version mismatch logic
+    val OlderTestkit = "org.apache.pekko" %% "pekko-http-testkit" % "1.1.0" // scala-steward:off
   }
 
   object Cats {
@@ -66,11 +68,11 @@ object Dependencies {
   }
 
   object Pureconfig {
-    private val version = "0.17.8"
-    val Pureconfig = "com.github.pureconfig" %% "pureconfig" % "0.17.8"
+    private val version = "0.17.9"
+    val Pureconfig = "com.github.pureconfig" %% "pureconfig" % version
     object Scala3 {
-      val Core = "com.github.pureconfig" %% "pureconfig-core" % "0.17.8"
-      val Generic = "com.github.pureconfig" %% "pureconfig-generic-scala3" % "0.17.8"
+      val Core = "com.github.pureconfig" %% "pureconfig-core" % version
+      val Generic = "com.github.pureconfig" %% "pureconfig-generic-scala3" % version
     }
   }
 


### PR DESCRIPTION
The release should be 1.1.0

* fixed conhub erroneously depending on Akka
* fixed bincompat checks